### PR TITLE
Add theme support.

### DIFF
--- a/pages/index.css
+++ b/pages/index.css
@@ -1,3 +1,5 @@
+@import url(../src/themes/themes.css);
+
 * {
   font-family: sans-serif;
 }
@@ -10,7 +12,12 @@ body {
   padding: 2em;
 }
 
-select-sk, multi-select-sk {
+select-sk,
+multi-select-sk {
   border: 1px solid grey;
   margin: 3px;
+}
+
+a {
+  color: var(--primary);
 }

--- a/pages/index.html
+++ b/pages/index.html
@@ -14,7 +14,7 @@
       }
     </script>
   </head>
-<body class=darkmode>
+<body class="darkmode body-sk">
   <button id=toggle-darkmode>Toggle Dark Mode</button>
   <h2 id="Buttons">Button Styles</h2>
   <button>Plain</button>

--- a/pages/index.html
+++ b/pages/index.html
@@ -14,7 +14,8 @@
       }
     </script>
   </head>
-<body>
+<body class=darkmode>
+  <button id=toggle-darkmode>Toggle Dark Mode</button>
   <h2 id="Buttons">Button Styles</h2>
   <button>Plain</button>
   <button class=action>Action</button>

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,5 +40,9 @@ import { errorMessage } from 'elements-sk/errorMessage';
 import './index.css';
 
 document.getElementById('make_error').addEventListener('click', () => {
-	errorMessage('Oh no, there was a problem!', 4000 /* ms*/);
-})
+  errorMessage('Oh no, there was a problem!', 4000 /* ms */);
+});
+
+document.getElementById('toggle-darkmode').addEventListener('click', () => {
+  document.body.classList.toggle('darkmode');
+});

--- a/src/checkbox-sk/checkbox-sk.css
+++ b/src/checkbox-sk/checkbox-sk.css
@@ -1,4 +1,4 @@
-@import url(../colors.css);
+@import url(../themes/themes.css);
 
 checkbox-sk {
   display: block;
@@ -16,11 +16,10 @@ checkbox-sk label {
 
 checkbox-sk .box {
   margin-right: 0.4em;
-  border: 4px solid var(--blue);
+  border: 4px solid var(--primary);
   width: 16px;
   height: 16px;
-  background: white;
-  border-radius: 4px;
+  background: var(--on-primary);
 }
 
 checkbox-sk input {
@@ -30,24 +29,20 @@ checkbox-sk input {
 }
 
 checkbox-sk input:checked + .box {
-  background: var(--blue);
+  background: var(--primary);
 }
 
 checkbox-sk input:focus + .box {
-  outline: dashed 2px var(--blue);
+  outline: dashed 2px var(--on-surface);
   outline-offset: 3px;
 }
 
 checkbox-sk:hover .box {
-  background: var(--light-blue);
-}
-
-checkbox-sk input:checked:hover + .box {
-  background: var(--gray);
+  border-color: var(--primary-variant);
 }
 
 checkbox-sk input:checked + .box {
-  background: var(--blue);
+  background: var(--primary);
 }
 
 checkbox-sk[hidden] {
@@ -55,12 +50,11 @@ checkbox-sk[hidden] {
 }
 
 checkbox-sk input:disabled + .box {
-  border: 4px solid var(--gray);
-  background: white;
+  border: 4px solid var(--disabled);
+  background: var(--background);
 }
 
 checkbox-sk input:disabled:checked + .box {
-  border: 4px solid var(--gray);
-  background: var(--gray);
-  color: var(--gray);
+  border: 4px solid var(--disabled);
+  background: var(--disabled);
 }

--- a/src/multi-select-sk/multi-select-sk.css
+++ b/src/multi-select-sk/multi-select-sk.css
@@ -1,44 +1,40 @@
-@import url(../colors.css);
+@import url(../themes/themes.css);
 
 multi-select-sk,
 multi-select-sk > * {
   padding: 0.6em;
-  background-color: var(--white);
+  background-color: var(--surface-1dp);
+  color: var(--on-surface);
   border: none;
   outline: none;
   line-height: 20px;
   vertical-align: middle;
-  border-radius: 4px;
 }
 
 multi-select-sk {
-  border: solid 1px var(--light-blue);
+  border: solid 1px var(--on-surface);
   display: block;
 }
 
-
 multi-select-sk > [selected] {
-  background: var(--light-gray);
+  background: var(--surface-2dp);
+}
+
+multi-select-sk > * {
+  border: var(--surface-1dp) solid 1px;
 }
 
 multi-select-sk > *:focus,
 multi-select-sk:focus {
-  border: solid 1px var(--light-gray);
-  outline: dashed 2px var(--blue);
+  outline: dashed 2px var(--on-surface);
   outline-offset: 3px;
 }
 
 multi-select-sk > *:hover {
-  background-color: var(--dark-white);
-}
-
-multi-select-sk > *:focus {
-  background-color: var(--dark-white);
-  transition: background-color 0.1s cubic-bezier(0.4, 0, 0.2, 1);
+  border: var(--surface-2dp) solid 1px;
 }
 
 multi-select-sk > *[selected] {
-  background-color: var(--light-blue);
-  color: var(--blue);
+  background-color: var(--surface-2dp);
+  color: var(--on-surface);
 }
-

--- a/src/nav-links-sk/nav-links-sk.css
+++ b/src/nav-links-sk/nav-links-sk.css
@@ -1,11 +1,11 @@
-@import url(../colors.css);
+@import url(../themes/themes.css);
 
 nav-links-sk {
   display: none;
   position: absolute;
   z-index: 200;
-  background: var(--white);
-  border: solid 1px var(--light-gray);
+  border: solid 1px var(--on-surface);
+  background: var(--surface);
   margin-left: 16px;
 }
 
@@ -16,10 +16,11 @@ nav-links-sk[shown] {
 nav-links-sk a {
   display: block;
   padding: 12px;
-  color: var(--blue);
-  fill: var(--blue);
+  background: var(--surface);
+  color: var(--on-surface);
+  fill: var(--on-surface);
 }
 
 nav-links-sk a:hover {
-  background: var(--light-gray);
+  background: var(--surface-1dp);
 }

--- a/src/radio-sk/radio-sk.css
+++ b/src/radio-sk/radio-sk.css
@@ -1,4 +1,4 @@
-@import url(../colors.css);
+@import url(../themes/themes.css);
 
 radio-sk {
   display: block;
@@ -16,10 +16,10 @@ radio-sk label {
 
 radio-sk .box {
   margin-right: 0.4em;
-  border: 4px solid var(--blue);
+  border: 4px solid var(--primary);
   width: 16px;
   height: 16px;
-  background: var(--white);
+  background: var(--background);
   border-radius: 50%;
 }
 
@@ -30,24 +30,20 @@ radio-sk input {
 }
 
 radio-sk input:checked + .box {
-  background: var(--blue);
+  background: var(--primary);
 }
 
 radio-sk input:focus + .box {
-  outline: dashed 2px var(--blue);
+  outline: dashed 2px var(--primary);
   outline-offset: 3px;
 }
 
 radio-sk:hover .box {
-  background: var(--dark-white);
-}
-
-radio-sk input:checked:hover + .box {
-  background: var(--gray);
+  border-color: var(--primary-variant);
 }
 
 radio-sk input:checked + .box {
-  background: var(--blue);
+  background: var(--primary);
 }
 
 radio-sk[hidden] {
@@ -55,12 +51,11 @@ radio-sk[hidden] {
 }
 
 radio-sk input:disabled + .box {
-  border: 4px solid var(--gray);
-  background: var(--white);
+  border: 4px solid var(--disabled);
+  background: var(--background);
 }
 
 radio-sk input:disabled:checked + .box {
-  border: 4px solid var(--gray);
-  background: var(--gray);
-  color: var(gray);
+  border: 4px solid var(--disabled);
+  background: var(--disabled);
 }

--- a/src/select-sk/select-sk.css
+++ b/src/select-sk/select-sk.css
@@ -1,44 +1,45 @@
-@import url(../colors.css);
+@import url(../themes/themes.css);
 
 select-sk,
 select-sk > * {
   padding: 0.6em;
-  background-color: var(--white);
+  background-color: var(--surface-1dp);
+  color: var(--on-surface);
   border: none;
   outline: none;
   line-height: 20px;
   vertical-align: middle;
-  border-radius: 4px;
 }
 
 select-sk {
-  border: solid 1px var(--light-blue);
+  border: solid 1px var(--on-surface);
   display: block;
 }
 
-
 select-sk > [selected] {
-  background: var(--light-gray);
+  background: var(--surface-2dp);
+}
+
+select-sk > * {
+  border: var(--surface-1dp) solid 1px;
 }
 
 select-sk > *:focus,
 select-sk:focus {
-  border: solid 1px var(--light-gray);
-  outline: dashed 2px var(--blue);
+  outline: dashed 2px var(--on-surface);
   outline-offset: 3px;
 }
 
 select-sk > *:hover {
-  background-color: var(--dark-white);
+  border: var(--surface-2dp) solid 1px;
 }
 
 select-sk > *:focus {
-  background-color: var(--dark-white);
+  background-color: var(--surface-2dp);
   transition: background-color 0.1s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 select-sk > *[selected] {
-  background-color: var(--light-blue);
-  color: var(--blue);
+  background-color: var(--surface-2dp);
+  color: var(--on-surface);
 }
-

--- a/src/spinner-sk/spinner-sk.css
+++ b/src/spinner-sk/spinner-sk.css
@@ -1,4 +1,4 @@
-@import url(../colors.css);
+@import url(../themes/themes.css);
 
 spinner-sk {
   margin: 6px;
@@ -6,8 +6,8 @@ spinner-sk {
   border-radius: 50%;
   width: 32px;
   height: 32px;
-  border: 8px solid var(--light-blue);
-  border-left: 8px solid var(--blue);
+  border: 8px solid var(--primary);
+  border-left: 8px solid var(--primary-variant);
   animation: spinner-sk-spin 1.5s infinite linear;
 }
 
@@ -17,12 +17,9 @@ spinner-sk[active] {
 
 @keyframes spinner-sk-spin {
   0% {
-    transform:
-    rotate(0deg);
+    transform: rotate(0deg);
   }
   100% {
-    transform:
-    rotate(360deg);
+    transform: rotate(360deg);
   }
 }
-

--- a/src/styles/buttons/buttons.css
+++ b/src/styles/buttons/buttons.css
@@ -1,90 +1,72 @@
-@import url(../../colors.css);
+@import url(../../themes/themes.css);
 /*
  *  A set of styles to make buttons and select/options look more Material Design-ish.
  **/
 button {
   min-width: 5.14em;
-  background-color: var(--white);
-  color: var(--blue);
-  fill: var(--blue);
+  background-color: var(--surface);
+  color: var(--on-surface);
+  fill: var(--on-surface);
   text-align: center;
   text-transform: uppercase;
   outline: none;
-  border-radius: 4px;
   padding: 0.6em 1.2em;
-  border: solid lightgray 1px;
+  border: solid var(--on-surface) 1px;
   margin: 0.6em;
   height: 3em;
-  transition: box-shadow 0.1s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 2px 2px 2px 0 var(--light-gray);
 }
 
 button:hover {
-  background: var(--dark-white);
+  background: var(--surface-1dp);
 }
 
 button.action:hover {
-  background: var(--light-blue);
-  color: var(--black);
+  background: var(--primary-variant);
+  color: var(--on-primary-variant);
 }
 
 button:focus {
-  outline: dashed 2px var(--blue);
+  outline: dashed 2px var(--on-surface);
   outline-offset: 3px;
 }
 
-button:active {
-  background-color: var(--blue);
-  transition: background-color 0.1s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 2px 2px 8px 0 var(--light-gray);
+button:active,
+button.action:active,
+button.fab:active {
+  background-color: var(--background);
+  color: var(--on-background);
+  fill: var(--on-background);
 }
 
 button:disabled {
-  color: var(--gray);
-  fill: var(--gray);
-  background-color: var(--white);
-}
-
-button.action:active {
-  background-color: var(--light-blue);
-  transition: background-color 0.1s color 0.1s cubic-bezier(0.4, 0, 0.2, 1);
+  background: var(--disabled);
+  border-color: var(--on-disabled);
+  color: var(--on-disabled);
+  fill: var(--on-disabled);
 }
 
 button.action {
-  color: var(--white);
-  fill: var(--white);
-  background: var(--blue);
-  border: solid rgba(0,0,0,0) 1px;
+  color: var(--on-primary);
+  fill: var(--on-primary);
+  background: var(--primary);
+  border: solid rgba(0, 0, 0, 0) 1px;
 }
 
 button.action:disabled {
-  color: var(--white);
-  fill: var(--white);
-  background: var(--gray);
-  border: solid rgba(0,0,0,0) 1px;
+  background: var(--disabled);
+  color: var(--on-disabled);
 }
 
 button.fab {
+  color: var(--on-secondary);
+  fill: var(--on-secondary);
+  background: var(--secondary);
   border-radius: 50%;
+  border: none;
   padding: 10px;
   width: 48px;
   height: 48px;
   min-width: 0px;
   font-weight: bold;
-  color: var(--white);
-  background: var(--red);
   font-size: 22px;
-  transition: box-shadow 0.1s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 2px 2px 8px 0 var(--gray);
 }
-
-button.fab:hover {
-  background: var(--light-red);
-  color: var(--black);
-}
-
-button.fab:active {
-  background: var(--red);
-  box-shadow: 2px 2px 5px 0 var(--light-gray);
-}
-

--- a/src/styles/select/select.css
+++ b/src/styles/select/select.css
@@ -1,42 +1,43 @@
-@import url(../../colors.css);
+@import url(../../themes/themes.css);
 /*
  * Styles for select and options to make them look better.
  */
 select,
 option {
   padding: 0.6em;
-  background-color: var(--white);
+  background-color: var(--surface);
+  color: var(--on-surface);
+  fill: var(--on-surface);
   border: none;
   outline: none;
   line-height: 20px;
   vertical-align: middle;
-  border-radius: 4px;
 }
 
 select {
-  border: solid 1px var(--light-blue);
+  border: solid 1px var(--on-surface);
   margin: 0.6em;
 }
 
-select option:focus,
 select:focus {
-  border: solid 1px var(--light-gray);
-  outline: dashed 2px var(--blue);
+  outline: dashed 2px var(--on-surface);
   outline-offset: 3px;
 }
 
 option:hover {
-  background-color: var(--dark-white);
+  background-color: var(--surface-1dp);
 }
 
 option:focus {
-  background-color: var(--dark-white);
+  background-color: var(--primary);
+  color: var(--on-primary);
   transition: background-color 0.1s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 option:checked {
-  background-color: var(--light-blue);
-  color: var(--blue);
+  background-color: var(--primary);
+  color: var(--on-primary);
+  fill: var(--on-primary);
 }
 
 select {

--- a/src/tabs-panel-sk/tabs-panel-sk.css
+++ b/src/tabs-panel-sk/tabs-panel-sk.css
@@ -1,8 +1,7 @@
-@import url(../colors.css);
+@import url(../themes/themes.css);
 
 tabs-panel-sk {
   display: block;
-  border: solid 4px var(--blue);
   margin: 0;
   padding: 16px;
   margin-top: -4px;

--- a/src/tabs-sk/tabs-sk.css
+++ b/src/tabs-sk/tabs-sk.css
@@ -1,4 +1,4 @@
-@import url(../colors.css);
+@import url(../themes/themes.css);
 
 tabs-sk > button {
   margin: 0;
@@ -6,16 +6,18 @@ tabs-sk > button {
   box-shadow: none;
   border-radius: 0;
   border: none;
-  color: var(--gray);
-  fill: var(--gray);
-  background-color: var(--light-blue);
-  border-bottom: solid 4px var(--blue);
+  color: var(--on-background);
+  fill: var(--on-background);
+  background-color: var(--background);
+  border-bottom: solid 4px var(--on-background);
 }
 
 tabs-sk > button.selected {
-  background: var(--blue);
+  background: var(--surface);
   border: none;
   box-shadow: none;
-  color: var(--white);
-  fill: var(--white);
+  color: var(--primary);
+  fill: var(--primary);
+  border-bottom: solid 4px var(--primary);
+  font-weight: bold;
 }

--- a/src/themes/color-palette.css
+++ b/src/themes/color-palette.css
@@ -1,0 +1,304 @@
+/*
+// Copyright 2017 Google Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+*/
+
+/*
+// The below is a CSS version of
+// github.com/material-components/material-components-web/blob/master/packages/mdc-theme/_color-palette.scss
+*/
+
+html {
+  --red-50: #ffebee;
+  --red-100: #ffcdd2;
+  --red-200: #ef9a9a;
+  --red-300: #e57373;
+  --red-400: #ef5350;
+  --red-500: #f44336;
+  --red-600: #e53935;
+  --red-700: #d32f2f;
+  --red-800: #c62828;
+  --red-900: #b71c1c;
+  --red-a100: #ff8a80;
+  --red-a200: #ff5252;
+  --red-a400: #ff1744;
+  --red-a700: #d50000;
+
+  --pink-50: #fce4ec;
+  --pink-100: #f8bbd0;
+  --pink-200: #f48fb1;
+  --pink-300: #f06292;
+  --pink-400: #ec407a;
+  --pink-500: #e91e63;
+  --pink-600: #d81b60;
+  --pink-700: #c2185b;
+  --pink-800: #ad1457;
+  --pink-900: #880e4f;
+  --pink-a100: #ff80ab;
+  --pink-a200: #ff4081;
+  --pink-a400: #f50057;
+  --pink-a700: #c51162;
+
+  --purple-50: #f3e5f5;
+  --purple-100: #e1bee7;
+  --purple-200: #ce93d8;
+  --purple-300: #ba68c8;
+  --purple-400: #ab47bc;
+  --purple-500: #9c27b0;
+  --purple-600: #8e24aa;
+  --purple-700: #7b1fa2;
+  --purple-800: #6a1b9a;
+  --purple-900: #4a148c;
+  --purple-a100: #ea80fc;
+  --purple-a200: #e040fb;
+  --purple-a400: #d500f9;
+  --purple-a700: #a0f;
+
+  --deep-purple-50: #ede7f6;
+  --deep-purple-100: #d1c4e9;
+  --deep-purple-200: #b39ddb;
+  --deep-purple-300: #9575cd;
+  --deep-purple-400: #7e57c2;
+  --deep-purple-500: #673ab7;
+  --deep-purple-600: #5e35b1;
+  --deep-purple-700: #512da8;
+  --deep-purple-800: #4527a0;
+  --deep-purple-900: #311b92;
+  --deep-purple-a100: #b388ff;
+  --deep-purple-a200: #7c4dff;
+  --deep-purple-a400: #651fff;
+  --deep-purple-a700: #6200ea;
+
+  --indigo-50: #e8eaf6;
+  --indigo-100: #c5cae9;
+  --indigo-200: #9fa8da;
+  --indigo-300: #7986cb;
+  --indigo-400: #5c6bc0;
+  --indigo-500: #3f51b5;
+  --indigo-600: #3949ab;
+  --indigo-700: #303f9f;
+  --indigo-800: #283593;
+  --indigo-900: #1a237e;
+  --indigo-a100: #8c9eff;
+  --indigo-a200: #536dfe;
+  --indigo-a400: #3d5afe;
+  --indigo-a700: #304ffe;
+
+  --blue-50: #e3f2fd;
+  --blue-100: #bbdefb;
+  --blue-200: #90caf9;
+  --blue-300: #64b5f6;
+  --blue-400: #42a5f5;
+  --blue-500: #2196f3;
+  --blue-600: #1e88e5;
+  --blue-700: #1976d2;
+  --blue-800: #1565c0;
+  --blue-900: #0d47a1;
+  --blue-a100: #82b1ff;
+  --blue-a200: #448aff;
+  --blue-a400: #2979ff;
+  --blue-a700: #2962ff;
+
+  --light-blue-50: #e1f5fe;
+  --light-blue-100: #b3e5fc;
+  --light-blue-200: #81d4fa;
+  --light-blue-300: #4fc3f7;
+  --light-blue-400: #29b6f6;
+  --light-blue-500: #03a9f4;
+  --light-blue-600: #039be5;
+  --light-blue-700: #0288d1;
+  --light-blue-800: #0277bd;
+  --light-blue-900: #01579b;
+  --light-blue-a100: #80d8ff;
+  --light-blue-a200: #40c4ff;
+  --light-blue-a400: #00b0ff;
+  --light-blue-a700: #0091ea;
+
+  --cyan-50: #e0f7fa;
+  --cyan-100: #b2ebf2;
+  --cyan-200: #80deea;
+  --cyan-300: #4dd0e1;
+  --cyan-400: #26c6da;
+  --cyan-500: #00bcd4;
+  --cyan-600: #00acc1;
+  --cyan-700: #0097a7;
+  --cyan-800: #00838f;
+  --cyan-900: #006064;
+  --cyan-a100: #84ffff;
+  --cyan-a200: #18ffff;
+  --cyan-a400: #00e5ff;
+  --cyan-a700: #00b8d4;
+
+  --teal-50: #e0f2f1;
+  --teal-100: #b2dfdb;
+  --teal-200: #80cbc4;
+  --teal-300: #4db6ac;
+  --teal-400: #26a69a;
+  --teal-500: #009688;
+  --teal-600: #00897b;
+  --teal-700: #00796b;
+  --teal-800: #00695c;
+  --teal-900: #004d40;
+  --teal-a100: #a7ffeb;
+  --teal-a200: #64ffda;
+  --teal-a400: #1de9b6;
+  --teal-a700: #00bfa5;
+
+  --green-50: #e8f5e9;
+  --green-100: #c8e6c9;
+  --green-200: #a5d6a7;
+  --green-300: #81c784;
+  --green-400: #66bb6a;
+  --green-500: #4caf50;
+  --green-600: #43a047;
+  --green-700: #388e3c;
+  --green-800: #2e7d32;
+  --green-900: #1b5e20;
+  --green-a100: #b9f6ca;
+  --green-a200: #69f0ae;
+  --green-a400: #00e676;
+  --green-a700: #00c853;
+
+  --light-green-50: #f1f8e9;
+  --light-green-100: #dcedc8;
+  --light-green-200: #c5e1a5;
+  --light-green-300: #aed581;
+  --light-green-400: #9ccc65;
+  --light-green-500: #8bc34a;
+  --light-green-600: #7cb342;
+  --light-green-700: #689f38;
+  --light-green-800: #558b2f;
+  --light-green-900: #33691e;
+  --light-green-a100: #ccff90;
+  --light-green-a200: #b2ff59;
+  --light-green-a400: #76ff03;
+  --light-green-a700: #64dd17;
+
+  --lime-50: #f9fbe7;
+  --lime-100: #f0f4c3;
+  --lime-200: #e6ee9c;
+  --lime-300: #dce775;
+  --lime-400: #d4e157;
+  --lime-500: #cddc39;
+  --lime-600: #c0ca33;
+  --lime-700: #afb42b;
+  --lime-800: #9e9d24;
+  --lime-900: #827717;
+  --lime-a100: #f4ff81;
+  --lime-a200: #eeff41;
+  --lime-a400: #c6ff00;
+  --lime-a700: #aeea00;
+
+  --yellow-50: #fffde7;
+  --yellow-100: #fff9c4;
+  --yellow-200: #fff59d;
+  --yellow-300: #fff176;
+  --yellow-400: #ffee58;
+  --yellow-500: #ffeb3b;
+  --yellow-600: #fdd835;
+  --yellow-700: #fbc02d;
+  --yellow-800: #f9a825;
+  --yellow-900: #f57f17;
+  --yellow-a100: #ffff8d;
+  --yellow-a200: #ff0;
+  --yellow-a400: #ffea00;
+  --yellow-a700: #ffd600;
+
+  --amber-50: #fff8e1;
+  --amber-100: #ffecb3;
+  --amber-200: #ffe082;
+  --amber-300: #ffd54f;
+  --amber-400: #ffca28;
+  --amber-500: #ffc107;
+  --amber-600: #ffb300;
+  --amber-700: #ffa000;
+  --amber-800: #ff8f00;
+  --amber-900: #ff6f00;
+  --amber-a100: #ffe57f;
+  --amber-a200: #ffd740;
+  --amber-a400: #ffc400;
+  --amber-a700: #ffab00;
+
+  --orange-50: #fff3e0;
+  --orange-100: #ffe0b2;
+  --orange-200: #ffcc80;
+  --orange-300: #ffb74d;
+  --orange-400: #ffa726;
+  --orange-500: #ff9800;
+  --orange-600: #fb8c00;
+  --orange-700: #f57c00;
+  --orange-800: #ef6c00;
+  --orange-900: #e65100;
+  --orange-a100: #ffd180;
+  --orange-a200: #ffab40;
+  --orange-a400: #ff9100;
+  --orange-a700: #ff6d00;
+
+  --deep-orange-50: #fbe9e7;
+  --deep-orange-100: #ffccbc;
+  --deep-orange-200: #ffab91;
+  --deep-orange-300: #ff8a65;
+  --deep-orange-400: #ff7043;
+  --deep-orange-500: #ff5722;
+  --deep-orange-600: #f4511e;
+  --deep-orange-700: #e64a19;
+  --deep-orange-800: #d84315;
+  --deep-orange-900: #bf360c;
+  --deep-orange-a100: #ff9e80;
+  --deep-orange-a200: #ff6e40;
+  --deep-orange-a400: #ff3d00;
+  --deep-orange-a700: #dd2c00;
+
+  --brown-50: #efebe9;
+  --brown-100: #d7ccc8;
+  --brown-200: #bcaaa4;
+  --brown-300: #a1887f;
+  --brown-400: #8d6e63;
+  --brown-500: #795548;
+  --brown-600: #6d4c41;
+  --brown-700: #5d4037;
+  --brown-800: #4e342e;
+  --brown-900: #3e2723;
+
+  --grey-50: #fafafa;
+  --grey-100: #f5f5f5;
+  --grey-200: #eee;
+  --grey-300: #e0e0e0;
+  --grey-400: #bdbdbd;
+  --grey-500: #9e9e9e;
+  --grey-600: #757575;
+  --grey-700: #616161;
+  --grey-800: #424242;
+  --grey-900: #212121;
+
+  --blue-grey-50: #eceff1;
+  --blue-grey-100: #cfd8dc;
+  --blue-grey-200: #b0bec5;
+  --blue-grey-300: #90a4ae;
+  --blue-grey-400: #78909c;
+  --blue-grey-500: #607d8b;
+  --blue-grey-600: #546e7a;
+  --blue-grey-700: #455a64;
+  --blue-grey-800: #37474f;
+  --blue-grey-900: #263238;
+
+  --white: #ffffff;
+  --black: #000000;
+}

--- a/src/themes/color-palette.css
+++ b/src/themes/color-palette.css
@@ -22,7 +22,7 @@
 
 /*
 // The below is a CSS version of
-// github.com/material-components/material-components-web/blob/master/packages/mdc-theme/_color-palette.scss
+// https://github.com/material-components/material-components-web/blob/master/packages/mdc-theme/_color-palette.scss
 */
 
 html {

--- a/src/themes/themes.css
+++ b/src/themes/themes.css
@@ -1,0 +1,115 @@
+/* A basic color theme and associated dark theme inspired by
+   https://material.io/design/color/dark-theme.html.
+
+ Can be imported via:
+
+    @import '~elements-sk/themes/themes';
+*/
+
+@import url(./color-palette.css);
+
+/* Define Color Palette */
+html {
+  /* See https://material.io/design/color/dark-theme.html for how to use each
+     of the below. */
+  --primary: var(--blue-800);
+  --on-primary: var(--white);
+  --primary-variant: var(--blue-600);
+  --on-primary-variant: var(--white);
+  --secondary: var(--deep-orange-800);
+  --on-secondary: var(--white);
+  --background: var(--grey-50);
+  --on-background: var(--black);
+  --surface: var(--white);
+  --on-surface: var(--black);
+  --surface-1dp: var(--grey-100);
+  --surface-2dp: var(--grey-300);
+  --disabled: var(--grey-100);
+  --on-disabled: var(--grey-700);
+  --error: var(--red-900);
+  --on-error: var(--white);
+  --transparent-overlay: rgba(0, 0, 0, 0.5);
+}
+
+/* Class to override colors with dark theme */
+.darkmode {
+  --primary: var(--purple-200);
+  --on-primary: var(--black);
+  --primary-variant: var(--deep-purple-700);
+  --on-primary-variant: var(--white);
+  --secondary: var(--teal-200);
+  --on-secondary: var(--black);
+  --background: var(--black);
+  --on-background: var(--white);
+  --surface: var(--grey-700);
+  --surface-1dp: var(--grey-800);
+  --surface-2dp: var(--grey-900);
+  --disabled: var(--grey-600);
+  --on-disabled: var(--grey-300);
+  --on-surface: var(--white);
+  --error: var(--pink-400);
+  --on-error: var(--black);
+  --transparent-overlay: rgba(255, 255, 255, 0.5);
+}
+
+/* Ensure the body respects darkmode */
+body {
+  background-color: var(--background);
+  color: var(--on-background);
+  fill: var(--on-background);
+}
+
+/* Helper classes to set elements to colors sets. */
+.primary-container-themes-sk {
+  background-color: var(--primary);
+  color: var(--on-primary);
+  fill: var(--on-primary);
+}
+
+.primary-themes-sk {
+  color: var(--primary);
+  fill: var(--primary);
+}
+
+.primary-variant-container-themes-sk {
+  background-color: var(--primary-variant);
+  color: var(--on-primary-variant);
+  fill: var(--on-primary-variant);
+}
+
+.primary-variant-themes-sk {
+  color: var(--primary-variant);
+  fill: var(--primary-variant);
+}
+
+.secondary-container-themes-sk {
+  background-color: var(--secondary);
+  color: var(--on-secondary);
+  fill: var(--on-secondary);
+}
+
+.secondary-themes-sk {
+  color: var(--secondary);
+  fill: var(--secondary);
+}
+
+.surface-themes-sk {
+  background-color: var(--surface);
+  color: var(--on-surface);
+  fill: var(--on-surface);
+}
+
+.error-container-themes-sk {
+  background-color: var(--error);
+  color: var(--on-error);
+  fill: var(--on-error);
+}
+
+.error-themes-sk {
+  color: var(--error);
+  fill: var(--error);
+}
+
+.overlay-themes-sk {
+  background-color: var(--transparent-overlay);
+}

--- a/src/themes/themes.css
+++ b/src/themes/themes.css
@@ -1,23 +1,45 @@
 /* A basic color theme and associated dark theme inspired by
    https://material.io/design/color/dark-theme.html.
 
- Can be imported via:
+Can be imported via:
 
     @import '~elements-sk/themes/themes';
+
+When choosing colors for a theme be sure to use the Material
+Design Color Tool:
+
+   https://material.io/resources/color/
+
+And follow the guidance on the use of colors for both light
+and dark themes:
+
+  https://material.io/design/color/the-color-system.html#color-theme-creation
+  https://material.io/design/color/dark-theme.html#ui-application
 */
 
 @import url(./color-palette.css);
 
 /* Define Color Palette */
 html {
-  /* See https://material.io/design/color/dark-theme.html for how to use each
-     of the below. */
+  /* See https://material.io/design/color/dark-theme.html for how to use each of
+     the CSS variables below.
+
+     This theme was generated using the Material Design Color Tool with the
+     following selections:
+
+     https://material.io/resources/color/#!/?view.left=1&view.right=0&secondary.color=D84315&primary.color=1565C0
+
+     The "Accessibility" tab shows the text colors to use for legibility.
+
+     The colors were chosen to meet MD guidelines and come as close as possible
+     to the color scheme elements-sk had before theme support was added.
+     */
   --primary: var(--blue-800);
   --on-primary: var(--white);
-  --primary-variant: var(--blue-600);
-  --on-primary-variant: var(--white);
+  --primary-variant: #5e92f3;
+  --on-primary-variant: var(--black);
   --secondary: var(--deep-orange-800);
-  --on-secondary: var(--white);
+  --on-secondary: var(--black);
   --background: var(--grey-50);
   --on-background: var(--black);
   --surface: var(--white);
@@ -31,11 +53,16 @@ html {
   --transparent-overlay: rgba(0, 0, 0, 0.5);
 }
 
-/* Class to override colors with dark theme */
+/* Class to override colors with dark theme.
+
+These colors match the names of the colors given in
+https://material.io/design/color/dark-theme.html#ui-application for the default
+dark color scheme.
+*/
 .darkmode {
   --primary: var(--purple-200);
   --on-primary: var(--black);
-  --primary-variant: var(--deep-purple-700);
+  --primary-variant: var(--indigo-700);
   --on-primary-variant: var(--white);
   --secondary: var(--teal-200);
   --on-secondary: var(--black);
@@ -52,18 +79,18 @@ html {
   --transparent-overlay: rgba(255, 255, 255, 0.5);
 }
 
-/* Ensure the body respects darkmode */
-body {
-  background-color: var(--background);
-  color: var(--on-background);
-  fill: var(--on-background);
-}
-
 /* Helper classes to set elements to colors sets. */
 .primary-container-themes-sk {
   background-color: var(--primary);
   color: var(--on-primary);
   fill: var(--on-primary);
+}
+
+/* Ensure the body respects darkmode */
+.body-sk {
+  background-color: var(--background);
+  color: var(--on-background);
+  fill: var(--on-background);
 }
 
 .primary-themes-sk {

--- a/src/toast-sk/toast-sk.css
+++ b/src/toast-sk/toast-sk.css
@@ -1,4 +1,4 @@
-@import url(../colors.css);
+@import url(../themes/themes.css);
 
 toast-sk {
   display: block;
@@ -6,10 +6,9 @@ toast-sk {
   position: fixed;
   left: 10px;
   bottom: 0;
-  color: var(--white);
-  fill: var(--white);
-  background: var(--blue);
-  border-radius: 4px;
+  color: var(--on-error);
+  fill: var(--on-error);
+  background: var(--error);
   padding: 10px 15px;
   opacity: 0;
   z-index: 20;


### PR DESCRIPTION
Add theme support.

This adds a couple theme values that didn't exist in the original:

    --surface-1dp
    --surface-2dp
    --disabled
    --on-disabled

Colors choices for the light them came from the material design theme designer with an eye towards making default elements-sk look close to what it was before themes.

https://material.io/resources/color/#!/?view.left=0&view.right=0&primary.color=1976D2

![light](https://user-images.githubusercontent.com/1726460/81739155-d4726d80-9468-11ea-9481-090d6428bbb1.png)


![dark](https://user-images.githubusercontent.com/1726460/81739162-d63c3100-9468-11ea-81a2-898ec7557995.png)
