### PR TITLE
Fix error-toast-sk handling of a 0 duration.

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -41,7 +41,7 @@ import { errorMessage } from 'elements-sk/errorMessage';
 import './index.scss';
 
 document.getElementById('make_error').addEventListener('click', () => {
-  errorMessage('Oh no, there was a problem!', 4000 /* ms */);
+  errorMessage('Oh no, there was a problem!', 0);
 });
 
 document.getElementById('toggle-darkmode').addEventListener('click', () => {

--- a/src/error-toast-sk/error-toast-sk.scss
+++ b/src/error-toast-sk/error-toast-sk.scss
@@ -1,0 +1,11 @@
+error-toast-sk {
+  button {
+    min-width: 0;
+    text-transform: none;
+    outline: none;
+    padding: 8px;
+    border: solid var(--on-surface) 1px;
+    margin: 0 0 0 8px;
+    height: initial;
+  }
+}

--- a/src/error-toast-sk/error-toast-sk.ts
+++ b/src/error-toast-sk/error-toast-sk.ts
@@ -44,24 +44,32 @@ import { ToastSk } from '../toast-sk/toast-sk';
 import '../toast-sk';
 import { ErrorSkEventDetail } from '../errorMessage';
 
-define('error-toast-sk', class extends HTMLElement {
-  private _toast: ToastSk | null = null;
+export class ErrorToastSk extends HTMLElement {
+  private toast: ToastSk | null = null;
+  private span: HTMLSpanElement | null = null;
 
   connectedCallback(): void {
-    this.innerHTML = '<toast-sk></toast-sk>';
-    this._toast = this.firstElementChild as ToastSk;
+    this.innerHTML = '<toast-sk><span></span><button title="Close">✗</button></toast-sk>';
+    this.toast = this.firstElementChild as ToastSk;
+    this.span = this.toast!.firstElementChild as HTMLSpanElement;
+
     document.addEventListener('error-sk', this);
+    this.querySelector('button')!.addEventListener('click', (e) => this.clickHandler());
   }
 
   disconnectedCallback(): void {
     document.removeEventListener('error-sk', this);
   }
 
-  handleEvent(e: CustomEvent<ErrorSkEventDetail>) {
-    if (e.detail.duration) {
-      this._toast!.duration = e.detail.duration;
-    }
-    this._toast!.textContent = e.detail.message;
-    this._toast!.show();
+  clickHandler() {
+    this.toast!.hide()
   }
-});
+
+  handleEvent(e: CustomEvent<ErrorSkEventDetail>) {
+    this.toast!.duration = e.detail.duration;
+    this.span!.textContent = e.detail.message
+    this.toast!.show();
+  }
+}
+
+define('error-toast-sk', ErrorToastSk);

--- a/src/error-toast-sk/error-toast-sk_test.ts
+++ b/src/error-toast-sk/error-toast-sk_test.ts
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/error-toast-sk/error-toast-sk_test.ts
+++ b/src/error-toast-sk/error-toast-sk_test.ts
@@ -1,0 +1,50 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ErrorToastSk } from "./error-toast-sk";
+import { errorMessage } from "../errorMessage"
+import { ToastSk } from '../toast-sk/toast-sk';
+
+const assert = chai.assert;
+
+describe('error-toast-sk', () => {
+  let container: HTMLDivElement;
+
+  beforeAll(async () => {
+    await customElements.whenDefined('error-toast-sk');
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container)
+  });
+
+  it('can be cancelled by clicking on the close button', () => {
+    container.innerHTML = `<error-toast-sk></error-toast-sk>`;
+    const errorToastSk = container.firstElementChild as ErrorToastSk;
+    const childToast = errorToastSk.querySelector('toast-sk') as ToastSk;
+
+    // Display the error toast and confirm it is displayed.
+    errorMessage('This is an error message which should display forever', 0);
+    assert.isTrue(childToast.hasAttribute('shown'));
+
+    // Click the close button.
+    errorToastSk.querySelector('button')!.click();
+    assert.isFalse(childToast.hasAttribute('shown'));
+  });
+});

--- a/src/error-toast-sk/index.ts
+++ b/src/error-toast-sk/index.ts
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 import './error-toast-sk.js';
+import './error-toast-sk.scss';

--- a/src/toast-sk/toast-sk.ts
+++ b/src/toast-sk/toast-sk.ts
@@ -17,13 +17,13 @@
  * @description <h2><code>toast-sk</code></h2>
  *
  * <p>
- *   Notification toast that pops up from the bottom of the screen
- *   when shown.
+ *   Notification toast that pops up from the bottom of the screen when shown.
+ *   Note that toast-sk doesn't add anyting inside the toast, it just presents
+ *   the existing child elements.
  * </p>
  *
- * @attr duration - The duration, in ms, to display the notification.
- *               Defaults to 5000. A value of 0 means to display
- *               forever.
+ * @attr duration - The duration, in ms, to display the notification. Defaults
+ *               to 5000. A value of 0 means to display forever.
  */
 import { define } from '../define';
 import { upgradeProperty } from '../upgradeProperty';


### PR DESCRIPTION
Setting a 0 duration is supposed to keep the toast displayed forever, but until this CL that was broken.

This CL also adds a close button to the toast for closing the toast, and a test.
